### PR TITLE
Sprite Fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "request": "launch",
             "name": "Amiga 500",
             "config": "A500",
-            "program": "${workspaceFolder}/build/hello",
+            "program": "${workspaceFolder}/build/unknown/hello",
             "kickstart": "${config:amiga.rom-paths.A500}",
             "internalConsoleOptions": "openOnSessionStart"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "request": "launch",
             "name": "Amiga 500",
             "config": "A500",
-            "program": "${workspaceFolder}/build/unknown/hello",
+            "program": "${workspaceFolder}/build/hello",
             "kickstart": "${config:amiga.rom-paths.A500}",
             "internalConsoleOptions": "openOnSessionStart"
         },

--- a/src/game.c
+++ b/src/game.c
@@ -39,6 +39,7 @@ static tSimpleBufferManager *s_pMainBuffer;
 static tSprite *s_pSprite0;
 static tSprite *s_pSprite1;
 static tBitMap *s_pSprite0Data;
+static tBitMap *s_pSprite1Data;
 
 static tFont *s_pFont;
 static tTextBitMap *s_pTextBitMap;
@@ -94,13 +95,22 @@ void gameGsCreate(void) {
      blitRect(s_pMainBuffer->pBack,16*i, 136, 16, 16,16+i);
   }
 
-  s_pSprite0Data = bitmapCreate(16, 34, 2, BMF_CLEAR); // 16x32 2BPP
+  s_pSprite0Data = bitmapCreate(16, 34, 2, BMF_CLEAR|BMF_INTERLEAVED); // 16x32 2BPP
   blitRect(s_pSprite0Data,0, 0, 16, 4, 0);
   blitRect(s_pSprite0Data,0, 4, 16, 4, 1);
   blitRect(s_pSprite0Data,0, 8, 16, 4, 2);
   blitRect(s_pSprite0Data,0, 12, 16, 4, 3);
+
+ 
+  // You need to use 2 bitmaps, cause the sprite writes information to the sprite data.
+  s_pSprite1Data = bitmapCreate(16, 34, 2, BMF_CLEAR|BMF_INTERLEAVED); // 16x32 2BPP
+  blitRect(s_pSprite1Data,0, 0, 16, 4, 0);
+  blitRect(s_pSprite1Data,0, 4, 16, 4, 1);
+  blitRect(s_pSprite1Data,0, 8, 16, 4, 2);
+  blitRect(s_pSprite1Data,0, 12, 16, 4, 3);
+  
   s_pSprite0 = spriteAdd(0, s_pSprite0Data); // Add sprite to channel 
-  s_pSprite1 = spriteAdd(3, s_pSprite0Data); // Add sprite to channel 
+  s_pSprite1 = spriteAdd(3, s_pSprite1Data); // Add sprite to channel 
   
   s_pSprite0->wX=100;
   s_pSprite0->wY=100;
@@ -142,7 +152,7 @@ void gameGsLoop(void) {
   }
 
   if(joyCheck(JOY1_UP)) {
-		s_pSprite0->wX-=2;
+		s_pSprite0->wY-=2;
 	}
 	if(joyCheck(JOY1_DOWN)) {
 		s_pSprite0->wY+=2;
@@ -154,10 +164,15 @@ void gameGsLoop(void) {
 		s_pSprite0->wX+=2;
 	}
   
+  spriteRequestMetadataUpdate(s_pSprite0);
+  
+  
   spriteProcess(s_pSprite0);
-   spriteProcess(s_pSprite1);
-
+  
+  
   spriteProcessChannel(0); // Should only be on create
+  spriteRequestMetadataUpdate(s_pSprite1);
+  spriteProcess(s_pSprite1);
   spriteProcessChannel(3); // Should only be on create
 
 


### PR DESCRIPTION
I always need the sprite data to be done as an interleaved bitmap for a sprite to display.

You also need separate data for each sprite, since the sprite writes information to the first line of the sprite data and the last line of the data., which is why the data is 2 extra lines in size,

On OCS/ECS the palette for sprites' colours is in the last 16 colours, (even on a 16-colour screen).

                16  Unused   00  |
                 17  Color 1  01  |
                 18  Color 2  10  |-- Sprites 0 and 1
                 19  Color 3  11 _|
                 20  Unused   00  |
                 21  Color 1  01  |
                 22  Color 2  10  |-- Sprites 2 and 3
                 23  Color 3  11 _|
                 24  Unused   00  |
                 25  Color 1  01  |
                 26  Color 2  10  |-- Sprites 4 and 5
                 27  Color 3  11 _|
                 28  Unused   00  |
                 29  Color 1  01  |
                 30  Color 2  10  |-- Sprites 6 and 7
                 31  Color 3  11 _|